### PR TITLE
Add test coverage for newer GHC versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
         ghc:
           - "8.6.5"
           - "8.8.4"
+          - "8.10.7"
+          - "9.0.2"
+          - "9.2.2"
     steps:
     - uses: actions/checkout@v2
 
@@ -69,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         stack: ["2.7.5"]
-        ghc: ["8.6.5", "8.8.4"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2"]
 
     steps:
     - uses: actions/checkout@v2

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -1,0 +1,10 @@
+resolver: lts-18.28
+
+allow-newer: true
+
+packages:
+- .
+
+extra-deps:
+- higgledy-0.4.2.0@sha256:7be6bd61fb75cfd04d0b292b61afe0a0548fe726311bdf5484d446bec3a7bebc,2260
+- named-0.3.0.1@sha256:16c23f330b9f0373c464fee44d48dfa0f9d561f35bfe73dfd6ea69459688d4e5,2325

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,0 +1,9 @@
+resolver: lts-19.6
+
+allow-newer: true
+
+packages:
+- .
+
+extra-deps:
+- higgledy-0.4.2.0@sha256:7be6bd61fb75cfd04d0b292b61afe0a0548fe726311bdf5484d446bec3a7bebc,2260


### PR DESCRIPTION
Adds GHC `8.10.8`, `9.0.2` and `9.2.2` (Cabal only, as there is not Stack LTS yet) to the test matrix.
These tests fail, but accurately reflect the current situation. 