### PR TITLE
Test docs-test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
 
     - name: Configure
       run: |
-        cabal configure --enable-tests --enable-benchmarks --enable-documentation --test-show-details=direct --write-ghc-environment-files=always
+        cabal configure --enable-tests --enable-benchmarks --enable-documentation --test-show-details=direct --write-ghc-environment-files=always -f builddocstest
 
     - name: Freeze
       run: |
-        cabal freeze
+        cabal freeze -f builddocstest
 
     - uses: actions/cache@v3
       name: Cache ~/.cabal/store
@@ -51,11 +51,11 @@ jobs:
 
     - name: Install dependencies
       run: |
-        cabal build all --only-dependencies
+        cabal build all --only-dependencies -f builddocstest
 
     - name: Build
       run: |
-        cabal build all
+        cabal build all -f builddocstest
 
     - name: Test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Test
       run: |
-        cabal test all
+        cabal test all -f builddocstest
 
     - name: Documentation
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
 
+    - name: Install build-tool dependencies
+      run: |
+        cabal install markdown-unlit
+  
     - name: Install dependencies
       run: |
         cabal build all --only-dependencies -f builddocstest


### PR DESCRIPTION
The `docs-test` test suite is only run when the `builddocstest` cabal flag is set.